### PR TITLE
fix: change build target

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,17 @@
 {
-  "presets": ["es2015", "stage-0", "react"]
+	"presets": [
+        ["env", {
+            "targets": {
+                "browsers": [
+                    "> 1%",
+                    "last 4 versions"
+                ]
+            },
+            "debug": false
+        }],
+		"react",
+        "stage-1"
+	],
+
+    "plugins": ["transform-object-assign"]
 }

--- a/package.json
+++ b/package.json
@@ -47,6 +47,8 @@
   "devDependencies": {
     "babel-cli": "^6.14.0",
     "babel-loader": "^6.2.2",
+    "babel-plugin-transform-object-assign": "^6.22.0",
+    "babel-preset-env": "^1.6.1",
     "babel-preset-es2015": "^6.14.0",
     "babel-preset-react": "^6.11.1",
     "babel-preset-react-app": "^0.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -906,6 +906,12 @@ babel-plugin-transform-function-bind@^6.22.0:
     babel-plugin-syntax-function-bind "^6.8.0"
     babel-runtime "^6.22.0"
 
+babel-plugin-transform-object-assign@^6.22.0:
+  version "6.22.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-object-assign/-/babel-plugin-transform-object-assign-6.22.0.tgz#f99d2f66f1a0b0d498e346c5359684740caa20ba"
+  dependencies:
+    babel-runtime "^6.22.0"
+
 babel-plugin-transform-object-rest-spread@6.26.0, babel-plugin-transform-object-rest-spread@^6.22.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.26.0.tgz#0f36692d50fef6b7e2d4b3ac1478137a963b7b06"
@@ -1021,7 +1027,7 @@ babel-polyfill@^6.26.0:
     core-js "^2.5.0"
     regenerator-runtime "^0.10.5"
 
-babel-preset-env@1.6.1:
+babel-preset-env@1.6.1, babel-preset-env@^1.6.1:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/babel-preset-env/-/babel-preset-env-1.6.1.tgz#a18b564cc9b9afdf4aae57ae3c1b0d99188e6f48"
   dependencies:


### PR DESCRIPTION
Use a more compatible build set to be usable across more browsers.

- Install babel-preset-env
- Install transform-object-assign
- Change to use env in .babelrc