### PR TITLE
Update react peer dep to support v17

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "homepage": "https://github.com/JimLiu/bbcode-to-react#readme",
   "dependencies": {},
   "peerDependencies": {
-    "react": "^0.14.0 || ^15.0.0 || ^16.0.0"
+    "react": "^0.14.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
   },
   "devDependencies": {
     "babel-cli": "^6.14.0",


### PR DESCRIPTION
Newer npm versions more strongly enforce peer dependency requirements on npm install. This means that attempting to use this package against React 17 will fail to install unless using the `--legacy-peer-deps` flag. This change fixes that.